### PR TITLE
fix(overlay): position the dimming overlay based on the direction of the transition

### DIFF
--- a/addon/transitions/move-over-half.js
+++ b/addon/transitions/move-over-half.js
@@ -8,6 +8,7 @@ export default function moveOverHalf(dimension, direction, opts) {
   var firstStep;
   var property;
   var measure;
+  var elementToOverlay;
 
   var darkOpacity = 0.75;
   if (direction > 0) {
@@ -15,15 +16,17 @@ export default function moveOverHalf(dimension, direction, opts) {
     overlayParams = {
       opacity: [0, darkOpacity]
     };
+    elementToOverlay = this.newElement;
   } else {
     // moving left
     overlayParams = {
       opacity: [darkOpacity, 0]
     };
+    elementToOverlay = this.oldElement;
   }
 
   var overlay = jQuery('<div class="transition-overlay"></div>');
-  this.oldElement.append(overlay);
+  elementToOverlay.append(overlay);
 
   if (dimension.toLowerCase() === 'x') {
     property = 'translateX';
@@ -53,7 +56,7 @@ export default function moveOverHalf(dimension, direction, opts) {
       animate(overlay, overlayParams, opts),
       animate(this.oldElement, oldParams, opts),
       animate(this.newElement, newParams, opts, 'moving-in')
-    ]);
+    ]).then(() => overlay.remove());
   });
 }
 


### PR DESCRIPTION
In iOS's transitions, only the previous item on the stack is faded in and out (verified on my iPhone). This PR adds the overlay to the "covered" element (instead of always to the "old" one), as well as removing it from the DOM after the transition completes.

FYI, I'm not 100% certain on the "removing [the overlay] from the DOM" part, but it WOMM. ;)
